### PR TITLE
Updated image name 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,5 +35,5 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |
-            facetscloud/event-exporter:${{ github.run_number }}
-            facetscloud/event-exporter:latest
+            facetscloud/event-exporter-multiarch:${{ github.run_number }}
+            facetscloud/event-exporter-multiarch:latest


### PR DESCRIPTION
Issue: 
- Since Jenkins also created the image with same name i.e event-exporter with tag 18(pinned in helm chart), thus raising PR to differentiate the image name conflict created by GHA (event-exporter:13) and Jenkins (event-exporter:18) 